### PR TITLE
Update VGM to use Vault 0.6+ response wrapping

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ _testmain.go
 
 dist/builds/
 dist/release/
+.idea/
 .DS_Store
 
 *.exe

--- a/README.md
+++ b/README.md
@@ -6,10 +6,12 @@ to other services who's lifecycles are managed by [Mesos](https://mesos.apache.o
 (such as [Marathon](https://mesosphere.github.io/marathon/)).
 
 VGM takes the Cubbyhole Authenication approach outlined by Jeff Mitchell on [Vault Blog](https://www.hashicorp.com/blog/vault-cubbyhole-principles.html).
+Specifically Vault response wrapping is used as outlined in the [Vault documentation](https://www.vaultproject.io/docs/concepts/response-wrapping.html).
 In short, a service will request a vault token from VGM supplying its Mesos task id. VGM will then check with Mesos to ensure that the task has been
-recently started, and if so, create 2 tokens (`temp` and `perm`). The `temp` token, which can only be used twice, will be first used to write a
-the `perm` token into it's own Cubbyhole. This `temp` token is then provided to the service which can use that token to retrieve the `perm` token.
-VGM can also ensure the correct policies are set on the `perm` token by using an internal configuration based on the task's name in Mesos.
+recently started, and if so, request the creation of 2 tokens (`temp` and `perm`). The `temp` token, which can only be used twice, will be first used
+by Vault internally to write the `perm` token into it's own Cubbyhole at the path `response`. This `temp` token is then provided to the service which
+can use that token to retrieve the `perm` token. VGM can also ensure the correct policies are set on the `perm` token by using an internal configuration
+based on the task's name in Mesos.
 
 ## Deploying
 

--- a/gatekeeper/gatekeeper.go
+++ b/gatekeeper/gatekeeper.go
@@ -69,9 +69,7 @@ func RequestVaultToken(taskId string) (string, error) {
 	}
 	gkAddr.Path = "/token"
 
-	gkTaskID := struct {
-		TaskId string `json:"task_id"`
-	}{taskId}
+	gkTaskID := gkTokenReq{TaskId: taskId}
 
 	gkReq, err := json.Marshal(gkTaskID)
 	if err != nil {
@@ -84,14 +82,9 @@ func RequestVaultToken(taskId string) (string, error) {
 	}
 	defer gkResp.Body.Close()
 
-	var gkTokResp struct {
-		OK     bool   `json:"ok"`
-		Token  string `json:"token"`
-		Status string `json:"status"`
-		Error  string `json:"error"`
-	}
+	gkTokResp := &gkTokenResp{}
 
-	if err := json.NewDecoder(gkResp.Body).Decode(&gkTokResp); err != nil {
+	if err := json.NewDecoder(gkResp.Body).Decode(gkTokResp); err != nil {
 		return "", err
 	}
 
@@ -130,13 +123,8 @@ func RequestVaultToken(taskId string) (string, error) {
 		return "", vaultErr
 	}
 
-	vaultSecret := struct {
-		Data struct {
-			Token string `json:"token"`
-		} `json:"data"`
-	}{}
-
-	if err := bodyDecoder.Decode(&vaultSecret); err != nil {
+	vaultSecret := &vaultSecret{}
+	if err := bodyDecoder.Decode(vaultSecret); err != nil {
 		return "", err
 	}
 

--- a/gatekeeper/gatekeeper.go
+++ b/gatekeeper/gatekeeper.go
@@ -102,7 +102,7 @@ func requestPermToken(tempToken string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	vaultAddr.Path = "/v1/cubbyhole/vault-token"
+	vaultAddr.Path = "/v1/cubbyhole/response"
 
 	req, err := http.NewRequest("GET", vaultAddr.String(), nil)
 	if err != nil {
@@ -120,12 +120,12 @@ func requestPermToken(tempToken string) (string, error) {
 		return "", err
 	}
 
-	vaultSecret := &vaultSecret{}
-	if err := json.NewDecoder(vaultResp.Body).Decode(vaultSecret); err != nil {
+	cubbyholeSecret := &cubbyholeSecret{}
+	if err := json.NewDecoder(vaultResp.Body).Decode(cubbyholeSecret); err != nil {
 		return "", err
 	}
 
-	return vaultSecret.Data.Token, nil
+	return cubbyholeSecret.Data.WrappedSecret.Token, nil
 }
 
 func EnvRequestVaultToken() (string, error) {

--- a/gatekeeper/types.go
+++ b/gatekeeper/types.go
@@ -1,0 +1,20 @@
+package gatekeeper
+
+type gkTokenReq struct {
+	TaskId string `json:"task_id"`
+}
+
+type gkTokenResp struct {
+	OK     bool   `json:"ok"`
+	Token  string `json:"token"`
+	Status string `json:"status"`
+	Error  string `json:"error"`
+}
+
+type vaultSecret struct {
+	Data vaultSecretData `json:"data"`
+}
+
+type vaultSecretData struct {
+	Token string `json:"token"`
+}

--- a/gatekeeper/types.go
+++ b/gatekeeper/types.go
@@ -40,8 +40,12 @@ type gkTokenResp struct {
 	Error  string `json:"error"`
 }
 
-type vaultSecret struct {
-	Data vaultSecretData `json:"data"`
+type cubbyholeSecret struct {
+	Data wrappedResponseData `json:"data"`
+}
+
+type wrappedResponseData struct {
+	WrappedSecret vaultSecretData `json:"response"`
 }
 
 type vaultSecretData struct {

--- a/gatekeeper/types.go
+++ b/gatekeeper/types.go
@@ -1,5 +1,34 @@
 package gatekeeper
 
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+)
+
+type VaultError struct {
+	Code   int      `json:"-"`
+	Errors []string `json:"errors"`
+}
+
+func (e VaultError) Error() string {
+	return fmt.Sprintf("%d: %s", e.Code, strings.Join(e.Errors, ", "))
+}
+
+func buildVaultError(resp *http.Response) error {
+	if resp.StatusCode == 200 {
+		return nil
+	}
+
+	vaultErr := &VaultError{Code: resp.StatusCode}
+	if err := json.NewDecoder(resp.Body).Decode(vaultErr); err != nil {
+		vaultErr.Errors = []string{"communication error", err.Error()}
+	}
+
+	return vaultErr
+}
+
 type gkTokenReq struct {
 	TaskId string `json:"task_id"`
 }

--- a/provider.go
+++ b/provider.go
@@ -89,7 +89,7 @@ func createWrappedToken(token string, opts interface{}, wrapTTL time.Duration) (
 	return t.WrapInfo.Token, nil
 }
 
-func createTokenPair(token string, p *policy, wrap bool) (string, error) {
+func createTokenPair(token string, p *policy) (string, error) {
 	pol := p.Policies
 	if len(pol) == 0 { // explicitly set the policy, else the token will inherit ours
 		pol = []string{"default"}
@@ -130,7 +130,6 @@ func Provide(c *gin.Context) {
 
 	var reqParams struct {
 		TaskId    string `json:"task_id"`
-		WrapToken bool   `json:"wrap_token"`
 	}
 	decoder := json.NewDecoder(c.Request.Body)
 	if err := decoder.Decode(&reqParams); err == nil {
@@ -185,7 +184,7 @@ func Provide(c *gin.Context) {
 			state.RLock()
 			policy := activePolicies.Get(task.Name)
 			state.RUnlock()
-			if tempToken, err := createTokenPair(token, policy, reqParams.WrapToken); err == nil {
+			if tempToken, err := createTokenPair(token, policy); err == nil {
 				log.Printf("Provided token pair for %s in %v. (Task Id: %s) (Task Name: %s). Policies: %v", remoteIp, time.Now().Sub(requestStartTime), reqParams.TaskId, task.Name, policy.Policies)
 				atomic.AddInt32(&state.Stats.Successful, 1)
 				usedTaskIds.Put(reqParams.TaskId, config.MaxTaskLife+1*time.Minute)

--- a/provider.go
+++ b/provider.go
@@ -6,6 +6,7 @@ import (
 	"github.com/franela/goreq"
 	"github.com/gin-gonic/gin"
 	"log"
+	"strconv"
 	"sync/atomic"
 	"time"
 )
@@ -47,17 +48,53 @@ func createToken(token string, opts interface{}) (string, error) {
 	}
 }
 
-func createTokenPair(token string, p *policy) (string, error) {
-	tempTokenOpts := struct {
-		Ttl      string   `json:"ttl"`
-		NumUses  int      `json:"num_uses"`
-		Policies []string `json:"policies"`
-		NoParent bool     `json:"no_parent"`
-	}{"10m", 2, []string{"default"}, true}
+func createWrappedToken(token string, opts interface{}, wrapTTL time.Duration) (string, error) {
+	wrapTTLSeconds := strconv.Itoa(int(wrapTTL.Seconds()))
+
+	r, err := VaultRequest{
+		goreq.Request{
+			Uri:             vaultPath("/v1/auth/token/create", ""),
+			Method:          "POST",
+			Body:            opts,
+			MaxRedirects:    10,
+			RedirectHeaders: true,
+		}.WithHeader("X-Vault-Token", token).WithHeader("X-Vault-Wrap-TTL", wrapTTLSeconds),
+	}.Do()
+	defer r.Body.Close()
+
+	if err != nil {
+		return "", err
+	}
+
+	if r.StatusCode != 200 {
+		var e vaultError
+		e.Code = r.StatusCode
+		if err := r.Body.FromJsonTo(&e); err == nil {
+			return "", e
+		} else {
+			e.Errors = []string{"communication error."}
+			return "", e
+		}
+	}
+
+	t := &vaultTokenResp{}
+	if err := r.Body.FromJsonTo(t); err != nil {
+		return "", err
+	}
+
+	if t.WrapInfo.Token == "" {
+		return "",  errors.New("Request for wrapped token did not return wrapped response")
+	}
+
+	return t.WrapInfo.Token, nil
+}
+
+func createTokenPair(token string, p *policy, wrap bool) (string, error) {
 	pol := p.Policies
 	if len(pol) == 0 { // explicitly set the policy, else the token will inherit ours
 		pol = []string{"default"}
 	}
+
 	permTokenOpts := struct {
 		Ttl      string            `json:"ttl,omitempty"`
 		Policies []string          `json:"policies"`
@@ -66,41 +103,7 @@ func createTokenPair(token string, p *policy) (string, error) {
 		NoParent bool              `json:"no_parent"`
 	}{time.Duration(time.Duration(p.Ttl) * time.Second).String(), pol, p.Meta, p.NumUses, true}
 
-	if tempToken, err := createToken(token, tempTokenOpts); err == nil {
-		if permToken, err := createToken(token, permTokenOpts); err == nil {
-			r, err := VaultRequest{goreq.Request{
-				Uri:    vaultPath("/v1/cubbyhole/vault-token", ""),
-				Method: "POST",
-				Body: struct {
-					Token string `json:"token"`
-				}{permToken},
-				MaxRedirects:    10,
-				RedirectHeaders: true,
-			}.WithHeader("X-Vault-Token", tempToken)}.Do()
-			if err == nil {
-				defer r.Body.Close()
-				switch r.StatusCode {
-				case 204:
-					return tempToken, nil
-				default:
-					var e vaultError
-					e.Code = r.StatusCode
-					if err := r.Body.FromJsonTo(&e); err == nil {
-						return "", e
-					} else {
-						e.Errors = []string{"communication error."}
-						return "", e
-					}
-				}
-			} else {
-				return "", err
-			}
-		} else {
-			return "", err
-		}
-	} else {
-		return "", err
-	}
+	return createWrappedToken(token, permTokenOpts, 10 * time.Minute)
 }
 
 func Provide(c *gin.Context) {
@@ -126,7 +129,8 @@ func Provide(c *gin.Context) {
 	}
 
 	var reqParams struct {
-		TaskId string `json:"task_id"`
+		TaskId    string `json:"task_id"`
+		WrapToken bool   `json:"wrap_token"`
 	}
 	decoder := json.NewDecoder(c.Request.Body)
 	if err := decoder.Decode(&reqParams); err == nil {
@@ -181,7 +185,7 @@ func Provide(c *gin.Context) {
 			state.RLock()
 			policy := activePolicies.Get(task.Name)
 			state.RUnlock()
-			if tempToken, err := createTokenPair(token, policy); err == nil {
+			if tempToken, err := createTokenPair(token, policy, reqParams.WrapToken); err == nil {
 				log.Printf("Provided token pair for %s in %v. (Task Id: %s) (Task Name: %s). Policies: %v", remoteIp, time.Now().Sub(requestStartTime), reqParams.TaskId, task.Name, policy.Policies)
 				atomic.AddInt32(&state.Stats.Successful, 1)
 				usedTaskIds.Put(reqParams.TaskId, config.MaxTaskLife+1*time.Minute)

--- a/unsealer.go
+++ b/unsealer.go
@@ -30,6 +30,11 @@ type vaultTokenResp struct {
 		LeaseDuration int    `json:"lease_duration"`
 		TTL           int    `json:"ttl"`
 	} `json:"auth"`
+	WrapInfo struct {
+		Token           string `json:"token"`
+		TTL             int    `json:"ttl"`
+		WrappedAccessor string `json:"wrapped_accessor"`
+	} `json:"wrap_info"`
 }
 
 type Unsealer interface {


### PR DESCRIPTION
This breaks compatibility with versions of Vault older than 0.6.

This covers this issue: https://github.com/ChannelMeter/vault-gatekeeper-mesos/issues/4