### PR TITLE
Added a WrappedTokenUnsealer - fixes #8

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,8 @@ VGM also supports the client environment variables used by vault such as, `VAULT
 
 `CUBBY_PATH` | `-cubby-path` - Path to key in cubbyhole. By default this is `/vault-token`.
 
+`WRAPPED_TOKEN_AUTH` | `-wrapped-token-auth` - Temporary vault authorization token that has a wrapped permanent vault token.
+
 `APP_ID` | `-auth-appid` - Use the `app-id` authorization method with this app id.
 
 `USER_ID_METHOD` | `-auth-userid-method` - With the `app-id` authorization method, this argument decides how VGM should generate the user id. Valid values are `mac` and `file`.

--- a/html.go
+++ b/html.go
@@ -37,6 +37,9 @@ const htmlTemplateVal = `<!DOCTYPE html>
       .active-form.active-cubby .visible-cubby {
         display: block;
       }
+      .active-form.active-wrapped-token .visible-wrapped-token {
+        display: block;
+      }
       .status-unsealed {
         display: {{.StatusUnsealed}};
       }
@@ -85,6 +88,7 @@ const htmlTemplateVal = `<!DOCTYPE html>
                 <option value="github">GitHub</option>
                 <option value="userpass">Username &amp; Password</option>
                 <option value="cubby">Cubby Method</option>
+                <option value="wrapped-token">Wrapped Token Method</option>
                 <option value="token">Token</option>
               </select>
             </div>
@@ -148,6 +152,12 @@ const htmlTemplateVal = `<!DOCTYPE html>
               <div class="form-group">
                 <label for="cubby_path">Cubby Method: Path</label>
                 <input type="password" class="form-control" id="cubby_path" name="cubby_path" placeholder="/vault-token">
+              </div>
+            </div>
+            <div class="form-section visible-wrapped-token">
+              <div class="form-group">
+                <label for="wrapped_token">Wrapped Token Method: Temp Token</label>
+                <input type="text" class="form-control" id="wrapped_token" name="wrapped_token">
               </div>
             </div>
             <div class="text-right">

--- a/routes.go
+++ b/routes.go
@@ -91,6 +91,8 @@ func Unseal(c *gin.Context) {
 		case "cubby":
 			request.Token = c.Request.FormValue("cubby_token")
 			request.CubbyPath = c.Request.FormValue("cubby_path")
+		case "wrapped-token":
+			request.Token = c.Request.FormValue("wrapped_token")
 		default:
 			c.JSON(400, struct {
 				Status string `json:"status"`
@@ -139,6 +141,10 @@ func Unseal(c *gin.Context) {
 		unsealer = CubbyUnsealer{
 			TempToken: request.Token,
 			Path:      request.CubbyPath,
+		}
+	case "wrapped-token":
+		unsealer = WrappedTokenUnsealer{
+			TempToken: request.Token,
 		}
 	default:
 		c.JSON(400, struct {


### PR DESCRIPTION
This allows users to unseal Gatekeeper with a token created and stored with Vault response wrapping, by providing the temp token which wraps the stored token. Implements the functionality asked for here https://github.com/ChannelMeter/vault-gatekeeper-mesos/issues/8 without removing the Cubbyhole unseal method.