### PR TITLE
Adding support for glob matching of policies

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,14 +83,26 @@ information on the different unseal methods.
 
 ## Policies
 
-VGM will create token's with given policies by using the data in it's `policies` config. This config is pulled from vault from the `generic` backend (and supplied by you).
+VGM will create token's with given policies by using the data in its `policies` config. This config is pulled from vault from the `generic` backend (and supplied by you).
 A `policies` config is a simple json structure, with the key name being the Mesos task name (with the Marathon framework this is your app name) and the value being select
-token options. A special '*' key is used as a catch all.
+token options. Policy names support glob-style matching, with the longest pattern taking priority. .
 
 ```json
 {
 	"web-server":{
 		"policies":["web"],
+		"meta":{"foo":"bar"},
+		"ttl":3000,
+		"num_uses":0,
+	},
+	"ChronosTask:my_special_task":{
+		"policies":["special_task"],
+		"meta":{"foo":"bar"},
+		"ttl":3000,
+		"num_uses":0,
+	},
+	"ChronosTask:*":{
+		"policies":["batch"],
 		"meta":{"foo":"bar"},
 		"ttl":3000,
 		"num_uses":0,
@@ -101,6 +113,8 @@ token options. A special '*' key is used as a catch all.
 	}
 }
 ```
+
+In the above, any task starting with `ChronosTask:` will get the `batch` policy except `ChronosTask:my_special_task`, which will get `special_task`.
 
 You will have to use the Vault API in order to set th epolicies to your backend. Assuming your policy is saved as `policy.json`, here's how to save that information using cURL.
 

--- a/policy.go
+++ b/policy.go
@@ -5,6 +5,8 @@ import (
 	"github.com/franela/goreq"
 	"log"
 	"path"
+	"sort"
+	"github.com/ryanuber/go-glob"
 )
 
 type policyLoadError struct {
@@ -24,6 +26,20 @@ type policy struct {
 
 type policies map[string]*policy
 
+// Type and methods to sort a list of policy keys
+// by descending length of key. Implements sort.Interface
+type policyKeyList []string
+func (k policyKeyList) Len() int {
+	return len(k)
+}
+func (k policyKeyList) Swap(i, j int) {
+	k[i], k[j]  = k[j], k[i]
+}
+func (k policyKeyList) Less(i, j int) bool {
+	return len(k[i]) > len(k[j])
+}
+
+
 var defaultPolicy = &policy{
 	Ttl: 21600,
 }
@@ -36,9 +52,30 @@ var defaultPolicies = map[string]*policy{
 var activePolicies = make(policies)
 
 func (p policies) Get(key string) *policy {
+	// First look for an exact match
 	if pol, ok := p[key]; ok {
 		return pol
-	} else if pol, ok := p["*"]; ok {
+	}
+
+	// Now we're going to check for globs
+	// Order the keys in descending order of length
+	// so that "foobar*" takes precedence over "foo*"
+	// Now organize the keys by length
+	policyKeys := make(policyKeyList, 0, )
+	for k := range p {
+		policyKeys = append(policyKeys, k)
+	}
+	sort.Sort(policyKeys)
+
+	// Iterate over the keys to find one that matches by glob
+	for _,pattern := range policyKeys {
+		if glob.Glob(pattern, key) {
+			return p[pattern]
+		}
+	}
+
+	// Finally look for a catchall
+	if pol, ok := p["*"]; ok {
 		return pol
 	} else {
 		return defaultPolicy

--- a/policy.go
+++ b/policy.go
@@ -3,10 +3,10 @@ package main
 import (
 	"fmt"
 	"github.com/franela/goreq"
+	"github.com/ryanuber/go-glob"
 	"log"
 	"path"
 	"sort"
-	"github.com/ryanuber/go-glob"
 )
 
 type policyLoadError struct {
@@ -29,16 +29,16 @@ type policies map[string]*policy
 // Type and methods to sort a list of policy keys
 // by descending length of key. Implements sort.Interface
 type policyKeyList []string
+
 func (k policyKeyList) Len() int {
 	return len(k)
 }
 func (k policyKeyList) Swap(i, j int) {
-	k[i], k[j]  = k[j], k[i]
+	k[i], k[j] = k[j], k[i]
 }
 func (k policyKeyList) Less(i, j int) bool {
 	return len(k[i]) > len(k[j])
 }
-
 
 var defaultPolicy = &policy{
 	Ttl: 21600,
@@ -61,14 +61,14 @@ func (p policies) Get(key string) *policy {
 	// Order the keys in descending order of length
 	// so that "foobar*" takes precedence over "foo*"
 	// Now organize the keys by length
-	policyKeys := make(policyKeyList, 0, )
+	policyKeys := make(policyKeyList, 0)
 	for k := range p {
 		policyKeys = append(policyKeys, k)
 	}
 	sort.Sort(policyKeys)
 
 	// Iterate over the keys to find one that matches by glob
-	for _,pattern := range policyKeys {
+	for _, pattern := range policyKeys {
 		if glob.Glob(pattern, key) {
 			return p[pattern]
 		}


### PR DESCRIPTION
Hi all,

We have a large number of Chronos jobs that all need Vault tokens.  Specifying each name individually is unsupportable, so I've added functionality to support glob patterns in policy names.  I've updated the README to show an example.  