### PR TITLE
Prevent InsecureSkipVerify flag from being ignored by goreq

### DIFF
--- a/request.go
+++ b/request.go
@@ -12,6 +12,10 @@ type VaultRequest struct {
 }
 
 func (r VaultRequest) Do() (*goreq.Response, error) {
+	config := goreq.DefaultTransport.(*http.Transport).TLSClientConfig
+	if config != nil {
+		r.Insecure = config.InsecureSkipVerify
+	}
 	resp, err := r.Request.Do()
 	for err == nil && resp.StatusCode == 307 {
 		io.Copy(ioutil.Discard, resp.Body)


### PR DESCRIPTION
The InsecureSkipVerify flag was being ignored because it relies on goreq's Insecure flag which isn't being set. In goreq, the InsecureSkipVerify flag gets overwritten if the transport has a TLSClientConfig.