### PR TITLE
Slim down the docker image by deleting extra cruft after we're done building

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,16 @@
 FROM golang:alpine
 
 ENV GIN_MODE release
-RUN apk add --update git bash && rm -rf /var/cache/apk/*
-RUN go get -d github.com/channelmeter/vault-gatekeeper-mesos && \
-	cd $GOPATH/src/github.com/channelmeter/vault-gatekeeper-mesos && \
-	git checkout tags/0.5.3
-RUN cd $GOPATH/src/github.com/channelmeter/vault-gatekeeper-mesos && \
-	/bin/bash ./build.bash && cp ./vltgatekeeper /bin/vltgatekeeper
+
+RUN apk add --update git bash && \
+    rm -rf /var/cache/apk/* && \
+    go get -d github.com/channelmeter/vault-gatekeeper-mesos && \
+    cd $GOPATH/src/github.com/channelmeter/vault-gatekeeper-mesos && \
+    git checkout tags/0.5.3 && \
+    /bin/bash ./build.bash && \
+    cp ./vltgatekeeper /bin/vltgatekeeper && \
+    rm -r $GOPATH/src/github.com/channelmeter/vault-gatekeeper-mesos && \
+    apk del git
 
 EXPOSE 9201
 


### PR DESCRIPTION
This reduces the container size by a noticeable amount for an alpine image. 

```
<none>                                                   <none>                                 9fdd0cddca79        5 seconds ago       276.7 MB
<none>                                                   <none>                                 c37d10ce8643        3 minutes ago       304.1 MB
```