### PR TITLE
Add methods to gatekeeper client sdk

### DIFF
--- a/gatekeeper/types.go
+++ b/gatekeeper/types.go
@@ -49,3 +49,31 @@ type vaultWrappedResponse struct {
 func (vr *vaultWrappedResponse) Unwrap(v interface{}) error {
 	return json.Unmarshal([]byte(vr.Data.WrappedSecret), v)
 }
+
+type GatekeeperStatus struct {
+	OK      bool                   `json:"ok"`
+	Started string                 `json:"started"`
+	Status  string                 `json:"status"`
+	Uptime  string                 `json:"uptime"`
+	Stats   map[string]interface{} `json:"stats"`
+}
+
+type UnsealRequest struct {
+	Type            string `json:"type"`
+	Token           string `json:"token"`
+	CubbyPath       string `json:"cubby_path"`
+	Username        string `json:"username"`
+	Password        string `json:"password"`
+	AppID           string `json:"app_id"`
+	UserIdMethod    string `json:"user_id_method"`
+	UserIdInterface string `json:"user_id_interface"`
+	UserIdPath      string `json:"user_id_path"`
+	UserIdHash      string `json:"user_id_hash"`
+	UserIdSalt      string `json:"user_id_salt"`
+}
+
+type GatekeeperResponse struct {
+	OK     bool   `json:"ok"`
+	Status string `json:"status"`
+	Error  string `json:"error"`
+}


### PR DESCRIPTION
Add some routines to the gatekeeper client helpful when interacting with it:

* GetStatus()
* IsSealed()
* Unseal()
* ReloadPolicies()

Should be self-explanatory. Let me know if you have questions or concerns. Thanks!