### PR TITLE
Add multi-token support for tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,8 @@ VGM also supports the client environment variables used by vault such as, `VAULT
 
 `TASK_LIFE` | `-task-life` - *Default: `2m`* - The maximum age of a task before VGM will refuse to issue tokens for it.
 
+`TASK_MULTI_TOKEN` | `-task-multi-token` - *Default: `false`* - Allow tasks to request multiple tokens before it reaches its maximum task life. This is useful for tasks that contain multiple processes and each needs to obtain a token.
+
 `RECREATE_TOKEN` | `-self-recreate-token` - *Default: `false`* - When the current token is reaching it's MAX_TTL (720h by default), recreate the token with the same policy instead of trying to renew (requires a sudo/root token, and for the token to have a ttl).
 
 ### Vault Startup Authorization Methods

--- a/gatekeeper.go
+++ b/gatekeeper.go
@@ -41,6 +41,7 @@ var config struct {
 	TlsKey           string
 	Mesos            string
 	MaxTaskLife      time.Duration
+	TaskMultiToken   bool
 	AppIdAuth        AppIdUnsealer
 	CubbyAuth        CubbyUnsealer
 	WrappedTokenAuth WrappedTokenUnsealer
@@ -111,6 +112,10 @@ func init() {
 	} else {
 		panic(d)
 	}
+	flag.BoolVar(&config.TaskMultiToken, "task-multi-token", func() bool {
+		b, err := strconv.ParseBool(defaultEnvVar("TASK_MULTI_TOKEN", "0"))
+		return err == nil && b
+	}(), "Allow tasks to request multiple tokens before it reaches its maximum task life.")
 }
 
 func recreateToken(token string, policies []string, ttl int) (string, error) {

--- a/provider.go
+++ b/provider.go
@@ -135,7 +135,7 @@ func Provide(c *gin.Context) {
 	}
 	decoder := json.NewDecoder(c.Request.Body)
 	if err := decoder.Decode(&reqParams); err == nil {
-		if usedTaskIds.Has(reqParams.TaskId) {
+		if !config.TaskMultiToken && usedTaskIds.Has(reqParams.TaskId) {
 			log.Printf("Rejected token request from %s (Task Id: %s). Reason: %v", remoteIp, reqParams.TaskId, errAlreadyGivenKey)
 			atomic.AddInt32(&state.Stats.Denied, 1)
 			c.JSON(403, struct {


### PR DESCRIPTION
Allow tasks to request multiple tokens before their maximum allowable time for fetching tokens is reached. This addresses an issue if a task contains multiple isolated processes that need to fetch secrets independently.