### PR TITLE
Added support for configuring desired Sealed HTTP response status code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,4 @@ vltgatekeeper
 vault
 .minimesos
 *.iml
+bin

--- a/README.md
+++ b/README.md
@@ -59,6 +59,8 @@ VGM also supports the client environment variables used by vault such as, `VAULT
 
 `RECREATE_TOKEN` | `-self-recreate-token` - *Default: `false`* - When the current token is reaching it's MAX_TTL (720h by default), recreate the token with the same policy instead of trying to renew (requires a sudo/root token, and for the token to have a ttl).
 
+`SEAL_HTTP_STATUS` | `-seal-http-status` - *Default: `200`* - Configures HTTP Status Code to be returned when querying /status.json.  By default uses 200 in both cases, but can be configured to return 429, for example, if the status is sealed.
+
 ### Vault Startup Authorization Methods
 
 `VAULT_TOKEN` - Vault authorization token to make requests with.

--- a/build.bash
+++ b/build.bash
@@ -54,4 +54,17 @@ name="${pkg}.gitFilesModified"
 value="$(git -C "${git_repo}" diff-index --name-only HEAD)"
 ldflags+=("-X" "\"${name}=${value}\"")
 
-go build -ldflags "${ldflags[*]}" -o "${output_filename}"
+GO_BUILD_CMD="go build -ldflags"
+GO_BUILD_OPT="${ldflags[*]}"
+
+# Build 386 amd64 binaries
+OS_PLATFORM_ARG=(linux windows darwin)
+OS_ARCH_ARG=(amd64)
+for OS in ${OS_PLATFORM_ARG[@]}; do
+  for ARCH in ${OS_ARCH_ARG[@]}; do
+    echo "Building binary for $OS/$ARCH..."
+    GOARCH=$ARCH GOOS=$OS CGO_ENABLED=0 $GO_BUILD_CMD "$GO_BUILD_OPT" -o "bin/${output_filename}_${OS-$ARCH}"
+  done
+done
+
+#go build -ldflags "${ldflags[*]}" -o "${output_filename}"

--- a/build.bash
+++ b/build.bash
@@ -54,17 +54,4 @@ name="${pkg}.gitFilesModified"
 value="$(git -C "${git_repo}" diff-index --name-only HEAD)"
 ldflags+=("-X" "\"${name}=${value}\"")
 
-GO_BUILD_CMD="go build -ldflags"
-GO_BUILD_OPT="${ldflags[*]}"
-
-# Build 386 amd64 binaries
-OS_PLATFORM_ARG=(linux windows darwin)
-OS_ARCH_ARG=(amd64)
-for OS in ${OS_PLATFORM_ARG[@]}; do
-  for ARCH in ${OS_ARCH_ARG[@]}; do
-    echo "Building binary for $OS/$ARCH..."
-    GOARCH=$ARCH GOOS=$OS CGO_ENABLED=0 $GO_BUILD_CMD "$GO_BUILD_OPT" -o "bin/${output_filename}_${OS-$ARCH}"
-  done
-done
-
-#go build -ldflags "${ldflags[*]}" -o "${output_filename}"
+go build -ldflags "${ldflags[*]}" -o "${output_filename}"

--- a/gatekeeper.go
+++ b/gatekeeper.go
@@ -36,6 +36,7 @@ var config struct {
 		GkPolicies string
 	}
 	SelfRecreate     bool
+	SealHttpStatus   int
 	ListenAddress    string
 	TlsCert          string
 	TlsKey           string
@@ -117,6 +118,15 @@ func init() {
 		b, err := strconv.ParseBool(defaultEnvVar("RECREATE_TOKEN", "0"))
 		return err == nil && b
 	}(), "When the current token is reaching it's MAX_TTL (720h by default), recreate the token with the same policy instead of trying to renew (requires a sudo/root token, and for the token to have a ttl).")
+
+	flag.IntVar(&config.SealHttpStatus, "seal-http-status", func() int {
+		b, err := strconv.ParseInt(defaultEnvVar("SEAL_HTTP_STATUS", "200"), 10, 0)
+		if err == nil {
+			return 200
+		} else {
+			return int(b)
+		}
+	}(), "Configures HTTP Status Code to be returned when querying /status.json. By default uses 200 in both cases, but can be configured to return 429, for example, if the status is sealed. (Overrides the SEAL_HTTP_STATUS variable if set.)")
 
 	if d, err := time.ParseDuration(defaultEnvVar("TASK_LIFE", "2m")); err == nil {
 		flag.DurationVar(&config.MaxTaskLife, "task-life", d, "The maximum amount of time that a task can be alive during which it can ask for a authorization token.")


### PR DESCRIPTION
 for /status.json when VGM is in Sealed status, allow configuring desired HTTP status code, for example, instead of default 200, use 429, or something like that.