### PR TITLE
Fix connection leak in client

### DIFF
--- a/gatekeeper/gatekeeper.go
+++ b/gatekeeper/gatekeeper.go
@@ -11,6 +11,8 @@ import (
 	"net/url"
 	"os"
 	"strconv"
+
+	"github.com/hashicorp/go-cleanhttp"
 )
 
 type Client struct {
@@ -65,19 +67,22 @@ func NewClient(vaultAddress, gatekeeperAddress string, certPool *x509.CertPool) 
 	client := new(Client)
 	client.VaultAddress = vaultAddress
 	client.GatekeeperAddress = gatekeeperAddress
-	tr := &http.Transport{
-		TLSClientConfig: &tls.Config{},
-	}
-	if certPool != nil {
-		tr.TLSClientConfig.RootCAs = certPool
-	}
-	client.HttpClient = &http.Client{Transport: tr}
+
 	if _, err := url.Parse(client.GatekeeperAddress); err != nil {
 		return nil, err
 	}
 	if _, err := url.Parse(client.VaultAddress); err != nil {
 		return nil, err
 	}
+
+	tr := cleanhttp.DefaultTransport()
+	tr.TLSClientConfig = &tls.Config{}
+	if certPool != nil {
+		tr.TLSClientConfig.RootCAs = certPool
+	}
+
+	client.HttpClient = &http.Client{Transport: tr}
+
 	return client, nil
 }
 


### PR DESCRIPTION
The default `http.Transport` (filled with zero values) will enable keepalives, with no idle connection limit or timeout.  This means that you will get one connection per `gatekeeper.Client` that never shuts down.  I've used hashicorp's `cleanhttp` package to get a transport with sensible defaults, but it could be done manually.

This can be worked around by futzing with the `client.HttpClient` after-the-fact, but I think it's better to do the right things out of the box.