### PR TITLE
Allow tasks to request multiple tokens before their maximum allowable

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,12 +125,38 @@ can only create tokens with a subset of its own policies.
 ## Policies
 
 
-VGM will create token's with given policies by using the data in its `policies` config. This config is pulled from vault from the `generic` backend (and supplied by you).
+VGM will create tokens with given policies by using the data in its `policies` config. This config is pulled from from vault, whose path is determined by a combination of a `generic` backend,
+which defaults to `secret`, and a key provided by you. For example, if you provide a policy path of `/gatekeeper-policy`, this translates to `/secret/gatekeeper-policy` in vault.
 A `policies` config is a simple json structure, with the key name being the Mesos task name (with the Marathon framework this is your app name), or ECS Task Definition name part of the ARN, and the value being select
-token options. Policy names support glob-style matching, with the longest pattern taking priority. .
+token options. Policy names support glob-style matching, with the longest pattern taking priority.
+
+
+#### Token Options
+`policies` (list, optional, default: default policy) - A list of policies to attach to the provided vault token
+
+`meta` (dict, optional) - Token metadata
+
+`ttl` (int, optional) - TTL of the provided token
+
+`num_uses` (int, optional) - Number of time a token can be used. 0 is translated to no limit
+
+`multi_fetch` (bool, optional, default: false) - Allows a task to request multiple tokens before it reaches its maximum task life. This is useful for a single task that contain multiple processes, each which require their own token
+
+`multi_fetch_limit` (int) - If `multi_fetch` is true, this value specifies how many times a task can obtain a token
+
+
+### Example policy config
 
 ```json
 {
+	"app-server":{
+		"policies":["app"],
+		"meta":{"foo":"bar"},
+		"multi_fetch":true,
+		"multi_fetch_limit":10,
+		"ttl":3000,
+		"num_uses":0,
+	},
 	"web-server":{
 		"policies":["web"],
 		"meta":{"foo":"bar"},

--- a/policy.go
+++ b/policy.go
@@ -18,10 +18,12 @@ func (ple policyLoadError) Error() string {
 }
 
 type policy struct {
-	Policies []string          `json:"policies"`
-	Meta     map[string]string `json:"meta,omitempty"`
-	Ttl      int               `json:"ttl,omitempty"`
-	NumUses  int               `json:"num_uses,omitempty"`
+	Policies        []string          `json:"policies"`
+	Meta            map[string]string `json:"meta,omitempty"`
+	Ttl             int               `json:"ttl,omitempty"`
+	NumUses         int               `json:"num_uses,omitempty"`
+	MultiFetch      bool              `json:"multi_fetch,omitempty"`
+	MultiFetchLimit int               `json:"multi_fetch_limit,omitempty"`
 }
 
 type policies map[string]*policy

--- a/ttlset.go
+++ b/ttlset.go
@@ -43,8 +43,6 @@ func (t *TtlSet) Put(key string, ttl time.Duration) {
 }
 
 func (t *TtlSet) UsageCount(key string) int {
-	//zz := t.s[key]
-	//return zz.fetchCount
 	return t.s[key].fetchCount
 }
 

--- a/ttlset.go
+++ b/ttlset.go
@@ -5,15 +5,20 @@ import (
 	"time"
 )
 
+type entry struct {
+	tstamp     time.Time
+	fetchCount int
+}
+
 type TtlSet struct {
 	sync.RWMutex
-	s    map[string]time.Time
+	s    map[string]entry
 	quit chan struct{}
 }
 
 func NewTtlSet() *TtlSet {
 	t := &TtlSet{}
-	t.s = make(map[string]time.Time)
+	t.s = make(map[string]entry)
 	t.quit = make(chan struct{})
 	go t.garbageCollector()
 	return t
@@ -28,8 +33,19 @@ func (t *TtlSet) Has(key string) bool {
 
 func (t *TtlSet) Put(key string, ttl time.Duration) {
 	t.Lock()
-	t.s[key] = time.Now().Add(ttl)
+	a := t.s[key]
+	if a.fetchCount == 0 {
+		a.tstamp = time.Now().Add(ttl)
+	}
+	a.fetchCount = a.fetchCount + 1
+	t.s[key] = a
 	t.Unlock()
+}
+
+func (t *TtlSet) UsageCount(key string) int {
+	//zz := t.s[key]
+	//return zz.fetchCount
+	return t.s[key].fetchCount
 }
 
 func (t *TtlSet) Destroy() {
@@ -42,7 +58,7 @@ func (t *TtlSet) Destroy() {
 func (t *TtlSet) cleanup() {
 	t.Lock()
 	for k, v := range t.s {
-		if time.Now().After(v) {
+		if time.Now().After(v.tstamp) {
 			delete(t.s, k)
 		}
 	}


### PR DESCRIPTION
time for fetching tokens is reached. This is useful for tasks that
contain multiple processes, each requiring its own token. This is
enabled on a per-task basis via policy config. This is in lieu of #37 

I updated the README to reflect this new option.

You'll notice I relocated the 'already given' logic further down the code base so I could have access to a task's policy config when making a decision to provide a token. Everything still works as previously designed!