### PR TITLE
Configurable token renewability

### DIFF
--- a/gatekeeper.go
+++ b/gatekeeper.go
@@ -36,6 +36,7 @@ var config struct {
 		GkPolicies string
 		GkPoliciesNested  bool
 	}
+	DefaultRenewable bool
 	SelfRecreate     bool
 	SealHttpStatus   int
 	ListenAddress    string
@@ -124,6 +125,11 @@ func init() {
 		b, err := strconv.ParseBool(defaultEnvVar("RECREATE_TOKEN", "0"))
 		return err == nil && b
 	}(), "When the current token is reaching it's MAX_TTL (720h by default), recreate the token with the same policy instead of trying to renew (requires a sudo/root token, and for the token to have a ttl).")
+
+	flag.BoolVar(&config.DefaultRenewable, "default-renewable-tokens", func() bool {
+		b, err := strconv.ParseBool(defaultEnvVar("DEFAULT_RENEWABLE", "1"))
+		return err == nil && b
+	}(), "The default value for renewable on tokens created.")
 
 	flag.IntVar(&config.SealHttpStatus, "seal-http-status", func() int {
 		b, err := strconv.ParseInt(defaultEnvVar("SEAL_HTTP_STATUS", "200"), 10, 0)

--- a/policy.go
+++ b/policy.go
@@ -24,6 +24,7 @@ type policy struct {
 	NumUses         int               `json:"num_uses,omitempty"`
 	MultiFetch      bool              `json:"multi_fetch,omitempty"`
 	MultiFetchLimit int               `json:"multi_fetch_limit,omitempty"`
+	Renewable	*bool		  `json:"renewable,omitempty"`
 }
 
 type policies map[string]*policy
@@ -44,11 +45,13 @@ func (k policyKeyList) Less(i, j int) bool {
 
 var defaultPolicy = &policy{
 	Ttl: 21600,
+	Renewable: &config.DefaultRenewable,
 }
 var defaultPolicies = map[string]*policy{
 	"*": &policy{
-		Policies: []string{"default"},
-		Ttl:      21600,
+		Policies: 	[]string{"default"},
+		Ttl:      	21600,
+		Renewable: 	&config.DefaultRenewable,
 	},
 }
 var activePolicies = make(policies)
@@ -118,6 +121,9 @@ func (p policies) Load(authToken string) error {
 					delete(p, k)
 				}
 				for k, v := range resp.Data {
+					if v.Renewable == nil {
+						v.Renewable = &config.DefaultRenewable
+					}
 					p[k] = v
 				}
 				log.Printf("Load/Reload policies complete. Policy count is %v.", len(p))

--- a/policy.go
+++ b/policy.go
@@ -24,7 +24,7 @@ type policy struct {
 	NumUses         int               `json:"num_uses,omitempty"`
 	MultiFetch      bool              `json:"multi_fetch,omitempty"`
 	MultiFetchLimit int               `json:"multi_fetch_limit,omitempty"`
-	Renewable	*bool		  `json:"renewable,omitempty"`
+	Renewable       *bool             `json:"renewable,omitempty"`
 }
 
 type policies map[string]*policy
@@ -44,14 +44,14 @@ func (k policyKeyList) Less(i, j int) bool {
 }
 
 var defaultPolicy = &policy{
-	Ttl: 21600,
+	Ttl:       21600,
 	Renewable: &config.DefaultRenewable,
 }
 var defaultPolicies = map[string]*policy{
 	"*": &policy{
-		Policies: 	[]string{"default"},
-		Ttl:      	21600,
-		Renewable: 	&config.DefaultRenewable,
+		Policies:  []string{"default"},
+		Ttl:       21600,
+		Renewable: &config.DefaultRenewable,
 	},
 }
 var activePolicies = make(policies)

--- a/provider.go
+++ b/provider.go
@@ -117,7 +117,7 @@ func createTokenPair(token string, p *policy) (string, error) {
 		NumUses   int               `json:"num_uses"`
 		NoParent  bool              `json:"no_parent"`
 		Renewable bool              `json:"renewable"`
-	}{time.Duration(time.Duration(p.Ttl) * time.Second).String(), pol, p.Meta, p.NumUses, true, true}
+	}{time.Duration(time.Duration(p.Ttl) * time.Second).String(), pol, p.Meta, p.NumUses, true, *p.Renewable}
 
 	return createWrappedToken(token, permTokenOpts, 10*time.Minute)
 }


### PR DESCRIPTION
Resolves #53 
Tokens created will remain renewable by default but allow for non-renewable tokens to be created.