### PR TITLE
Fix parsing of environment variable SEAL_HTTP_STATUS

### DIFF
--- a/gatekeeper.go
+++ b/gatekeeper.go
@@ -133,7 +133,7 @@ func init() {
 
 	flag.IntVar(&config.SealHttpStatus, "seal-http-status", func() int {
 		b, err := strconv.ParseInt(defaultEnvVar("SEAL_HTTP_STATUS", "200"), 10, 0)
-		if err == nil {
+		if err != nil {
 			return 200
 		} else {
 			return int(b)


### PR DESCRIPTION
When using environment variable SEAL_HTTP_STATUS, /status.json always returns 200