### PR TITLE
Update integration tests

### DIFF
--- a/integration.sh
+++ b/integration.sh
@@ -20,6 +20,8 @@ function run_tests() {
 
 	# wait for vault to startup
 	sleep 5
+	vault secrets move secret/ kv/
+	vault secrets enable -version=1 -path=secret kv
 	vault auth-enable userpass
 	# If using Docker for Mac, IP should be localhost
 	if [ "$(uname)" == "Darwin" ]; then

--- a/integration.sh
+++ b/integration.sh
@@ -22,7 +22,7 @@ function run_tests() {
 	sleep 5
 	vault secrets move secret/ kv/
 	vault secrets enable -version=1 -path=secret kv
-	vault auth-enable userpass
+	vault auth enable userpass
 	# If using Docker for Mac, IP should be localhost
 	if [ "$(uname)" == "Darwin" ]; then
 	    export VAULT_ADDR="http://127.0.0.1:8200"


### PR DESCRIPTION
This will set the Vault secret path to use unversioned secrets and allow the tests to pass. It also updates the auth-enable which is deprecated for the newer auth enable option.

Resolves #58 