### PR TITLE
Add TLS certificate reloading on SIGHUP

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,9 +37,9 @@ VGM also supports the client environment variables used by vault such as, `VAULT
 
 `LISTEN_ADDR` | `-listen` - *Default: `:9201`* - The address this service should listen on.
 
-`TLS_CERT` | `-tls-cert` - Path to TLS certificate. If this value is set, gatekeeper will be served over TLS.
+`TLS_CERT` | `-tls-cert` - Path to TLS certificate. If this value is set, gatekeeper will be served over TLS. File reread on SIGHUP.
 
-`TLS_KEY` | `-tls-key` - Path to TLS key. If this value is set, gatekeeper will be served over TLS.
+`TLS_KEY` | `-tls-key` - Path to TLS key. If this value is set, gatekeeper will be served over TLS. File reread on SIGHUP.
 
 `PROVIDER` | `-provider` - Configures the underlying Docker environment provider.  Currently supports `mesos` (default), `ecs` and `test` (Test provider should only be used during testing)
 

--- a/gatekeeper.go
+++ b/gatekeeper.go
@@ -81,8 +81,8 @@ func defaultEnvVar(key string, def string) (val string) {
 
 func init() {
 	flag.StringVar(&config.ListenAddress, "listen", defaultEnvVar("LISTEN_ADDR", ":9201"), "Hostname and port to listen on. (Overrides the LISTEN_ADDR environment variable if set.)")
-	flag.StringVar(&config.TlsCert, "tls-cert", defaultEnvVar("TLS_CERT", ""), "Path to TLS certificate. If this value is set, gatekeeper will be served over TLS.")
-	flag.StringVar(&config.TlsKey, "tls-key", defaultEnvVar("TLS_KEY", ""), "Path to TLS key. If this value is set, gatekeeper will be served over TLS.")
+	flag.StringVar(&config.TlsCert, "tls-cert", defaultEnvVar("TLS_CERT", ""), "Path to TLS certificate. If this value is set, gatekeeper will be served over TLS. File reread on SIGHUP.")
+	flag.StringVar(&config.TlsKey, "tls-key", defaultEnvVar("TLS_KEY", ""), "Path to TLS key. If this value is set, gatekeeper will be served over TLS. File reread on SIGHUP.")
 
 	flag.StringVar(&config.Provider, "provider", defaultEnvVar("DOCKER_PROVIDER", "mesos"), "Docker runtime provider (Supports mesos, ecs or test). (Overrides the DOCKER_PROVIDER environment variable if set.)")
 
@@ -415,7 +415,7 @@ func main() {
 	}
 	if config.TlsCert != "" || config.TlsKey != "" {
 		runFunc = func() error {
-			return r.RunTLS(config.ListenAddress, config.TlsCert, config.TlsKey)
+			return ListenAndServeTLS(config.ListenAddress, config.TlsCert, config.TlsKey, r)
 		}
 	}
 	if err := runFunc(); err != nil {

--- a/tlsutil.go
+++ b/tlsutil.go
@@ -1,0 +1,109 @@
+package main
+
+// Based on https://stackoverflow.com/a/40883377 and
+// https://github.com/robustirc/bridge/blob/v1.7.1/tlsutil/tlsutil.go.
+// Originally licensed under the BSD 3-Clause license:
+
+// Copyright © 2014-2015 The RobustIRC Authors. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//     * Redistributions of source code must retain the above copyright
+//       notice, this list of conditions and the following disclaimer.
+//
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//
+//     * Neither the name of RobustIRC nor the names of contributors may be used
+//       to endorse or promote products derived from this software without
+//       specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+// ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+// WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+import (
+	"crypto/tls"
+	"log"
+	"net/http"
+	"os"
+	"os/signal"
+	"sync"
+	"syscall"
+)
+
+type keypairReloader struct {
+	certMutex sync.RWMutex
+	cert      *tls.Certificate
+	certFile  string
+	keyFile   string
+}
+
+func NewKeypairReloader(certFile, keyFile string) (*keypairReloader, error) {
+	result := &keypairReloader{
+		certFile: certFile,
+		keyFile:  keyFile,
+	}
+	cert, err := tls.LoadX509KeyPair(certFile, keyFile)
+	if err != nil {
+		return nil, err
+	}
+	result.cert = &cert
+	go func() {
+		c := make(chan os.Signal, 1)
+		signal.Notify(c, syscall.SIGHUP)
+		for range c {
+			log.Printf("Received SIGHUP, reloading TLS certificate and key from %q and %q", certFile, keyFile)
+			if err := result.maybeReload(); err != nil {
+				log.Printf("Keeping old TLS certificate because the new one could not be loaded: %v", err)
+			}
+		}
+	}()
+	return result, nil
+}
+
+// This works just like http.ListenAndServeTLS but certificates are loaded into
+// a wrapper struct that reloads certificates from disk when a SIGHUP is
+// received.
+func ListenAndServeTLS(addr, certFile, keyFile string, handler http.Handler) error {
+	// From http.ListenAndServeTLS:
+	// https://github.com/golang/go/blob/release-branch.go1.10/src/net/http/server.go#L3000-L3003
+	server := &http.Server{Addr: addr, Handler: handler}
+
+	keypair, err := NewKeypairReloader(certFile, keyFile)
+	if err != nil {
+		return err
+	}
+	server.TLSConfig = &tls.Config{GetCertificate: keypair.GetCertificateFunc()}
+
+	// The certFile and keyFile arguments below are ignored if the GetCertificate field is not nil.
+	return server.ListenAndServeTLS("", "")
+}
+
+func (kpr *keypairReloader) maybeReload() error {
+	newCert, err := tls.LoadX509KeyPair(kpr.certFile, kpr.keyFile)
+	if err != nil {
+		return err
+	}
+	kpr.certMutex.Lock()
+	defer kpr.certMutex.Unlock()
+	kpr.cert = &newCert
+	return nil
+}
+
+func (kpr *keypairReloader) GetCertificateFunc() func(*tls.ClientHelloInfo) (*tls.Certificate, error) {
+	return func(clientHello *tls.ClientHelloInfo) (*tls.Certificate, error) {
+		kpr.certMutex.RLock()
+		defer kpr.certMutex.RUnlock()
+		return kpr.cert, nil
+	}
+}


### PR DESCRIPTION
This is needed when using short-lived TLS certificates, for example when using Let's Encrypt certificates or certificates issued from Vault itself.

Vault itself reloads configured certificates on SIGHUP. One difference is that here a signal handler is not set up if TLS is not configured, so if you don't configure TLS, SIGHUP will kill the vltgatekeeper process like it does currently.

The main thing I'm unsure of is where to place this code. There are some certificate-y things in [`gatekeeper/cert.go`](gatekeeper/cert.go) but they are a bit different than this stuff.

Thanks for the great project 🙏.