### PR TITLE
Feature/regexp policy matcher

### DIFF
--- a/gatekeeper.go
+++ b/gatekeeper.go
@@ -592,7 +592,7 @@ func (g *Gatekeeper) RenewalWorker(controlChan chan struct{}) {
 			if err := g.RenewToken(); err == nil {
 				log.Infof("Renewed Vault Token (original ttl: %v)", ttl)
 			} else {
-				log.Warn("Failed to renew Vault token. Is the policy set correctly? Gatekeeper will now be sealed: %v", err)
+				log.Warnf("Failed to renew Vault token. Is the policy set correctly? Gatekeeper will now be sealed: %v", err)
 				g.Seal()
 				return
 			}

--- a/policy/policy_test.go
+++ b/policy/policy_test.go
@@ -40,6 +40,11 @@ const samplePolicy = `{
 	"mesos:framework:service/*": {
 	    "roles":["mesos_framework_service"],
 	    "num_uses":1
+	},
+	"mesos:marathone:*":{
+		"roles":["mesos_marathone_taskA"],
+		"regexp":"\\d{4}\\w{2}\\.taskA",
+		"num_uses":1
 	}
 }`
 
@@ -88,6 +93,10 @@ func TestSamplePolicy(t *testing.T) {
 		}
 
 		if pass, _, actual := shouldContainAll(mustGet(pols.Get("mesos:framework:task2")), "mesos_framework_task"); pass {
+			t.Fatalf("Test of '%s' failed. 'task2' should not conatain permission of 'task'. Had: %v", "mesos:framework:task", actual)
+		}
+
+		if pass, _, actual := shouldContainAll(mustGet(pols.Get("mesos:marathone:6668wz.taskA")), "mesos_child", "mesos_marathone_taskA"); pass {
 			t.Fatalf("Test of '%s' failed. 'task2' should not conatain permission of 'task'. Had: %v", "mesos:framework:task", actual)
 		}
 


### PR DESCRIPTION
Addresses directly [this issue](https://github.com/nemosupremo/vault-gatekeeper/issues/76).
Reworked from prefix matching to regexp matching, while trying to preserve the current behavior.

Our motivation is due to Metronome prefixing `task_name` with a unique id, hence breaking the simple prefix matching.

**2019-08-28**: Run full tests and all pass.